### PR TITLE
fix: ignore unsupported SSH session request types

### DIFF
--- a/pkg/backend/ssh/server.go
+++ b/pkg/backend/ssh/server.go
@@ -313,6 +313,8 @@ func (s *Server) handleSession(ctx context.Context, channel ssh.Channel, request
 				s.executeCommand(ctx, channel, cmd.service, cmd.repoName, envs...)
 			}
 			return
+		case "auth-agent-req@openssh.com":
+			_ = req.Reply(false, nil)
 		default:
 			_ = req.Reply(false, nil)
 			sendExitStatus(channel, 1, "unsupported request type\n")


### PR DESCRIPTION
When a client connects with SSH agent forwarding enabled (e.g. ssh -A or ForwardAgent yes in config), the client sends an auth-agent-req@openssh.com request before the exec request. The current handleSession implementation treats any unrecognized request type as a fatal error, immediately closing the session and returning unsupported request type to the client. This causes all git operations to fail for users with agent forwarding enabled.

<img width="1034" height="372" alt="image" src="https://github.com/user-attachments/assets/be1a1504-0cf1-411a-b499-e5f22a8c2edb" />
