### PR TITLE
Serve ssh backend with go-git instead of git subprocesses

### DIFF
--- a/pkg/backend/ssh/server.go
+++ b/pkg/backend/ssh/server.go
@@ -3,18 +3,16 @@ package ssh
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
 	"golang.org/x/crypto/ssh"
 
-	"github.com/matrixhub-ai/hfd/internal/utils"
 	"github.com/matrixhub-ai/hfd/pkg/authenticate"
 	"github.com/matrixhub-ai/hfd/pkg/mirror"
 	"github.com/matrixhub-ai/hfd/pkg/permission"
@@ -273,7 +271,7 @@ func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
 func (s *Server) handleSession(ctx context.Context, channel ssh.Channel, requests <-chan *ssh.Request) {
 	defer channel.Close()
 
-	var envs []string
+	var gitProtocol string
 
 	for req := range requests {
 		switch req.Type {
@@ -289,7 +287,7 @@ func (s *Server) handleSession(ctx context.Context, channel ssh.Channel, request
 			switch env.Name {
 			case "GIT_PROTOCOL":
 				if repository.IsValidGitProtocol(env.Value) {
-					envs = append(envs, "GIT_PROTOCOL="+env.Value)
+					gitProtocol = env.Value
 				}
 				_ = req.Reply(true, nil)
 			default:
@@ -321,7 +319,7 @@ func (s *Server) handleSession(ctx context.Context, channel ssh.Channel, request
 			case repository.GitLFSTransfer:
 				sendExitStatus(channel, 1, "git-lfs-transfer is not supported\n")
 			default:
-				s.executeCommand(ctx, channel, cmd.service, cmd.repoName, envs...)
+				s.executeCommand(ctx, channel, cmd.service, cmd.repoName, gitProtocol)
 			}
 			return
 		case "auth-agent-req@openssh.com":
@@ -334,8 +332,8 @@ func (s *Server) handleSession(ctx context.Context, channel ssh.Channel, request
 	}
 }
 
-// executeCommand runs a git service command and pipes I/O through the SSH channel.
-func (s *Server) executeCommand(ctx context.Context, channel ssh.Channel, service string, repoName string, env ...string) {
+// executeCommand serves a git service in-process, reading and writing the SSH channel directly.
+func (s *Server) executeCommand(ctx context.Context, channel ssh.Channel, service string, repoName string, gitProtocol string) {
 	repoPath := s.storage.ResolvePath(repoName)
 	if repoPath == "" {
 		sendExitStatus(channel, 1, "repository not found\n")
@@ -386,7 +384,7 @@ func (s *Server) executeCommand(ctx context.Context, channel ssh.Channel, servic
 		}
 	}
 
-	_, err := s.openRepo(ctx, repoPath, repoName, service)
+	repo, err := s.openRepo(ctx, repoPath, repoName, service)
 	if err != nil {
 		if err == repository.ErrRepositoryNotExists {
 			sendExitStatus(channel, 1, "repository not found\n")
@@ -397,99 +395,55 @@ func (s *Server) executeCommand(ctx context.Context, channel ssh.Channel, servic
 		return
 	}
 
-	// For receive-pack with permission/receive hooks: use pipe-based approach
-	// to intercept pkt-line commands for permission checking before the push completes.
-	if service == repository.GitReceivePack && (s.preReceiveHookFunc != nil || s.postReceiveHookFunc != nil || s.mirror != nil) {
-		s.executeReceivePackWithHooks(ctx, channel, service, repoName, repoPath, env...)
+	if service == repository.GitReceivePack {
+		s.executeReceivePack(ctx, channel, repo, repoName, gitProtocol)
 		return
 	}
 
-	cmd := utils.Command(ctx, service, ".")
-	cmd.Dir = repoPath
-	cmd.Stdin = channel
-	cmd.Stdout = channel
-	cmd.Stderr = channel.Stderr()
-	if len(env) > 0 {
-		cmd.Env = append(os.Environ(), env...)
-	}
-
-	if err := cmd.Run(); err != nil {
-		slog.ErrorContext(ctx, "ssh protocol: command failed", "service", service, "error", err)
+	if err := repo.UploadPack(ctx, channel, gitProtocol); err != nil {
+		slog.ErrorContext(ctx, "ssh protocol: upload-pack failed", "repo", repoName, "error", err)
 		sendExitStatus(channel, 1, "")
 		return
 	}
 
-	exitCode := cmd.ProcessState.ExitCode()
-	sendExitStatus(channel, uint32(exitCode), "")
+	sendExitStatus(channel, 0, "")
 }
 
-// executeReceivePackWithHooks handles git-receive-pack using a pipe to intercept
-// pkt-line ref update commands. This allows the permission hook to inspect and
-// reject pushes before git-receive-pack processes the pack data.
-func (s *Server) executeReceivePackWithHooks(ctx context.Context, channel ssh.Channel, service string, repoName, repoPath string, env ...string) {
-	pr, pw := io.Pipe()
-	defer pr.Close()
+// errPreReceiveDenied marks a push rejected by the pre-receive hook without an error.
+var errPreReceiveDenied = errors.New("pre-receive denied")
 
-	cmd := utils.Command(ctx, service, ".")
-	cmd.Dir = repoPath
-	cmd.Stdin = pr
-	cmd.Stdout = channel
-	cmd.Stderr = channel.Stderr()
-	if len(env) > 0 {
-		cmd.Env = append(os.Environ(), env...)
+// executeReceivePack serves git-receive-pack in-process, wiring the configured
+// pre/post-receive hooks through the transport so pushes can be rejected before
+// any ref is updated.
+func (s *Server) executeReceivePack(ctx context.Context, channel ssh.Channel, repo *repository.Repository, repoName string, gitProtocol string) {
+	var hooks repository.ReceivePackHooks
+	if s.preReceiveHookFunc != nil {
+		hooks.PreReceive = func(ctx context.Context, updates []receive.RefUpdate) error {
+			if ok, err := s.preReceiveHookFunc(ctx, repoName, updates); err != nil {
+				slog.WarnContext(ctx, "ssh protocol: pre-receive hook error", "repo", repoName, "error", err)
+				return err
+			} else if !ok {
+				slog.WarnContext(ctx, "ssh protocol: pre-receive hook denied push", "repo", repoName)
+				return errPreReceiveDenied
+			}
+			return nil
+		}
+	}
+	hooks.PostReceive = func(ctx context.Context, updates []receive.RefUpdate) {
+		s.afterReceivePack(ctx, repoName, updates)
 	}
 
-	if err := cmd.Start(); err != nil {
-		pw.Close()
-		slog.ErrorContext(ctx, "ssh protocol: command start failed", "service", service, "error", err)
-		sendExitStatus(channel, 1, "")
-		return
-	}
-
-	// After git-receive-pack sends the ref advertisement through stdout→channel,
-	// the client sends pkt-line commands back through the channel. ParseRefUpdates
-	// reads these commands and returns a replay reader for forwarding.
-	updates, replay := receive.ParseRefUpdates(channel, repoPath)
-
-	// Pre-receive hook — can reject the push before pack data is processed.
-	if s.preReceiveHookFunc != nil && len(updates) > 0 {
-		if ok, err := s.preReceiveHookFunc(ctx, repoName, updates); err != nil {
-			slog.WarnContext(ctx, "ssh protocol: pre-receive hook denied push", "repo", repoName, "error", err)
-			cmd.Process.Kill()
-			pw.Close()
-			_ = cmd.Wait()
-			sendExitStatus(channel, 1, "")
-			return
-		} else if !ok {
-			slog.WarnContext(ctx, "ssh protocol: pre-receive hook denied push", "repo", repoName)
-			cmd.Process.Kill()
-			pw.Close()
-			_ = cmd.Wait()
+	if err := repo.ReceivePack(ctx, channel, gitProtocol, hooks); err != nil {
+		if errors.Is(err, errPreReceiveDenied) {
 			sendExitStatus(channel, 1, "pre-receive denied")
 			return
 		}
-	}
-
-	// Permission granted — forward the buffered pkt-line data and remaining
-	// channel input to git-receive-pack through the pipe.
-	go func() {
-		defer pw.Close()
-		if _, err := io.Copy(pw, replay); err != nil {
-			slog.WarnContext(ctx, "ssh protocol: error forwarding data to receive-pack", "repo", repoName, "error", err)
-		}
-	}()
-
-	if err := cmd.Wait(); err != nil {
-		slog.ErrorContext(ctx, "ssh protocol: command failed", "service", service, "error", err)
+		slog.ErrorContext(ctx, "ssh protocol: receive-pack failed", "repo", repoName, "error", err)
 		sendExitStatus(channel, 1, "")
 		return
 	}
 
-	// Fire post-receive hook with the ref updates.
-	s.afterReceivePack(ctx, repoName, updates)
-
-	exitCode := cmd.ProcessState.ExitCode()
-	sendExitStatus(channel, uint32(exitCode), "")
+	sendExitStatus(channel, 0, "")
 }
 
 func (s *Server) afterReceivePack(ctx context.Context, repoName string, updates []receive.RefUpdate) {

--- a/pkg/repository/serve.go
+++ b/pkg/repository/serve.go
@@ -1,0 +1,62 @@
+package repository
+
+import (
+	"context"
+	"io"
+
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+
+	"github.com/matrixhub-ai/hfd/pkg/receive"
+)
+
+// UploadPack serves the git-upload-pack protocol for the repository over rw
+// (stateful full-duplex, as used by the SSH transport). gitProtocol is the
+// client's GIT_PROTOCOL request value (e.g. "version=2") and selects the
+// protocol version via transport.ProtocolVersion.
+func (r *Repository) UploadPack(ctx context.Context, rw io.ReadWriter, gitProtocol string) error {
+	return transport.UploadPack(ctx, r.repo.Storer, io.NopCloser(rw), ioutil.WriteNopCloser(rw), &transport.UploadPackRequest{
+		GitProtocol: gitProtocol,
+	})
+}
+
+// ReceivePackHooks holds optional callbacks invoked while serving git-receive-pack.
+type ReceivePackHooks struct {
+	// PreReceive runs before any ref is updated. Returning a non-nil error
+	// rejects every ref with the error message as the reason.
+	PreReceive func(ctx context.Context, updates []receive.RefUpdate) error
+	// PostReceive runs after refs are updated with the successfully applied updates.
+	PostReceive func(ctx context.Context, updates []receive.RefUpdate)
+}
+
+// ReceivePack serves the git-receive-pack protocol for the repository over rw
+// (stateful full-duplex, as used by the SSH transport). gitProtocol is the
+// client's GIT_PROTOCOL request value and selects the protocol version via
+// transport.ProtocolVersion.
+func (r *Repository) ReceivePack(ctx context.Context, rw io.ReadWriter, gitProtocol string, hooks ReceivePackHooks) error {
+	opts := &transport.ReceivePackRequest{
+		GitProtocol: gitProtocol,
+	}
+	if hooks.PreReceive != nil {
+		opts.Hooks.PreReceive = func(ctx context.Context, info *transport.PreReceiveInfo) error {
+			return hooks.PreReceive(ctx, r.refUpdates(info.Commands))
+		}
+	}
+	if hooks.PostReceive != nil {
+		opts.Hooks.PostReceive = func(ctx context.Context, info *transport.PostReceiveInfo) error {
+			hooks.PostReceive(ctx, r.refUpdates(info.Commands))
+			return nil
+		}
+	}
+	return transport.ReceivePack(ctx, r.repo.Storer, io.NopCloser(rw), ioutil.WriteNopCloser(rw), opts)
+}
+
+// refUpdates converts packp ref update commands to receive.RefUpdate values.
+func (r *Repository) refUpdates(commands []*packp.Command) []receive.RefUpdate {
+	updates := make([]receive.RefUpdate, 0, len(commands))
+	for _, cmd := range commands {
+		updates = append(updates, receive.NewRefUpdate(cmd.Old.String(), cmd.New.String(), cmd.Name.String(), r.repoPath))
+	}
+	return updates
+}


### PR DESCRIPTION
Replaces the `git-upload-pack`/`git-receive-pack` subprocesses in the SSH backend with in-process serving via go-git v6 `transport.UploadPack`/`transport.ReceivePack`, reading and writing the SSH channel directly (stateful, not stateless-RPC). The pipe-based pkt-line interception in `executeReceivePackWithHooks` is gone; `preReceiveHookFunc`/`postReceiveHookFunc` now run through v6 `ReceivePackHooks`, with new `Repository.UploadPack`/`Repository.ReceivePack` in pkg/repository translating `packp.Command` to `receive.RefUpdate`. The client's `GIT_PROTOCOL` env request is passed through and mapped by `transport.ProtocolVersion`; `git-lfs-authenticate` and exit-status reporting keep the current behavior, with pre-receive denials additionally reported per-ref via report-status.

Verified with `go build ./...`, the unit tests, and the full e2e suite (ssh, hook/git/lfs/python matrix); SSH tests also pass with git forced to protocol.version 0, 1, and 2.

Fixes #183
