### PR TITLE
Fix go-git compatibility regressions found by git parity tests

### DIFF
--- a/pkg/backend/http/handler_git.go
+++ b/pkg/backend/http/handler_git.go
@@ -1,9 +1,11 @@
 package backend
 
 import (
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 
@@ -22,6 +24,17 @@ func gitProtocol(r *http.Request) string {
 		return ""
 	}
 	return value
+}
+
+// requestBody returns the request body, transparently inflating it when the
+// client sent Content-Encoding: gzip. Git clients gzip-compress smart-HTTP
+// request bodies larger than 1KiB (remote-curl.c post_rpc), and git
+// http-backend inflates them the same way (http-backend.c inflate_request).
+func requestBody(r *http.Request) (io.ReadCloser, error) {
+	if r.Header.Get("Content-Encoding") != "gzip" {
+		return r.Body, nil
+	}
+	return gzip.NewReader(r.Body)
 }
 
 // handleInfoRefs handles the /info/refs endpoint for git service discovery.
@@ -175,10 +188,19 @@ func (h *Handler) handleService(w http.ResponseWriter, r *http.Request, service 
 		return
 	}
 
+	body, err := requestBody(r)
+	if err != nil {
+		responseText(w, fmt.Sprintf("Failed to read request body: %v", err), http.StatusBadRequest)
+		return
+	}
+	defer func() {
+		_ = body.Close()
+	}()
+
 	w.Header().Set("Content-Type", fmt.Sprintf("application/x-%s-result", service))
 	w.Header().Set("Cache-Control", "no-cache")
 
-	err = repo.Stateless(r.Context(), w, r.Body, service, gitProtocol(r), h.receivePackHooks(repoName))
+	err = repo.Stateless(r.Context(), w, body, service, gitProtocol(r), h.receivePackHooks(repoName))
 	if err != nil {
 		// A pre-receive rejection has already been reported to the client
 		// in-protocol via report-status.
@@ -186,6 +208,7 @@ func (h *Handler) handleService(w http.ResponseWriter, r *http.Request, service 
 			slog.WarnContext(r.Context(), "pre-receive hook denied push", "repo", repoName, "error", err)
 			return
 		}
+		slog.ErrorContext(r.Context(), "failed to serve git service", "service", service, "repo", repoName, "error", err)
 		responseText(w, fmt.Sprintf("Failed to serve %s for %q: %v", service, repoName, err), http.StatusInternalServerError)
 		return
 	}

--- a/pkg/backend/http/handler_git.go
+++ b/pkg/backend/http/handler_git.go
@@ -31,10 +31,11 @@ func gitProtocol(r *http.Request) string {
 // request bodies larger than 1KiB (remote-curl.c post_rpc), and git
 // http-backend inflates them the same way (http-backend.c inflate_request).
 func requestBody(r *http.Request) (io.ReadCloser, error) {
-	if r.Header.Get("Content-Encoding") != "gzip" {
-		return r.Body, nil
+	switch r.Header.Get("Content-Encoding") {
+	case "gzip", "x-gzip":
+		return gzip.NewReader(r.Body)
 	}
-	return gzip.NewReader(r.Body)
+	return r.Body, nil
 }
 
 // handleInfoRefs handles the /info/refs endpoint for git service discovery.

--- a/pkg/backend/http/handler_gzip_test.go
+++ b/pkg/backend/http/handler_gzip_test.go
@@ -98,6 +98,9 @@ func TestHTTPGitGzipRequestBody(t *testing.T) {
 			t.Fatalf("gzip close: %v", err)
 		}
 		requirePackResponse(t, post(t, bytes.NewReader(compressed.Bytes()), "gzip"))
+
+		// http-backend.c accepts the legacy x-gzip alias as well.
+		requirePackResponse(t, post(t, bytes.NewReader(compressed.Bytes()), "x-gzip"))
 	})
 
 	t.Run("CorruptGzipBodyRejected", func(t *testing.T) {

--- a/pkg/backend/http/handler_gzip_test.go
+++ b/pkg/backend/http/handler_gzip_test.go
@@ -1,0 +1,109 @@
+package backend_test
+
+// Tests for gzip-compressed smart-HTTP request bodies: git clients compress
+// POST bodies larger than 1KiB (remote-curl.c post_rpc) and git http-backend
+// transparently inflates them, so the go-git handler must too.
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	backendhttp "github.com/matrixhub-ai/hfd/pkg/backend/http"
+	"github.com/matrixhub-ai/hfd/pkg/storage"
+)
+
+func TestHTTPGitGzipRequestBody(t *testing.T) {
+	root := t.TempDir()
+
+	st := storage.NewStorage(storage.WithRootDir(root))
+	repoPath := filepath.Join(st.RepositoriesDir(), "repo.git")
+	if err := os.MkdirAll(filepath.Dir(repoPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	runGitCmd(t, "", "init", "--bare", "--initial-branch=main", repoPath)
+
+	work := filepath.Join(root, "work")
+	runGitCmd(t, "", "init", "--initial-branch=main", work)
+	runGitCmd(t, work, "config", "user.email", "test@example.com")
+	runGitCmd(t, work, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(work, "file.txt"), []byte("content\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	runGitCmd(t, work, "add", ".")
+	runGitCmd(t, work, "commit", "-m", "c1")
+	runGitCmd(t, work, "push", repoPath, "main")
+	mainHash := strings.TrimSpace(runGitCmd(t, repoPath, "rev-parse", "refs/heads/main"))
+
+	srv := httptest.NewServer(backendhttp.NewHandler(backendhttp.WithStorage(st)))
+	t.Cleanup(srv.Close)
+
+	// A v0 upload-pack request equivalent to what git sends: want + done.
+	var plain bytes.Buffer
+	wantLine := fmt.Sprintf("want %s multi_ack_detailed\n", mainHash)
+	fmt.Fprintf(&plain, "%04x%s", 4+len(wantLine), wantLine)
+	plain.WriteString("0000")
+	fmt.Fprintf(&plain, "%04x%s", 4+len("done\n"), "done\n")
+
+	post := func(t *testing.T, body io.Reader, encoding string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/repo.git/git-upload-pack", body)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/x-git-upload-pack-request")
+		if encoding != "" {
+			req.Header.Set("Content-Encoding", encoding)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		return resp
+	}
+
+	requirePackResponse := func(t *testing.T, resp *http.Response) {
+		t.Helper()
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read response: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, body: %s", resp.StatusCode, data)
+		}
+		if !bytes.HasPrefix(data, []byte("0008NAK\n")) || !bytes.Contains(data, []byte("PACK")) {
+			t.Fatalf("expected NAK followed by a packfile, got %q...", data[:min(32, len(data))])
+		}
+	}
+
+	t.Run("PlainBody", func(t *testing.T) {
+		requirePackResponse(t, post(t, bytes.NewReader(plain.Bytes()), ""))
+	})
+
+	t.Run("GzipBody", func(t *testing.T) {
+		var compressed bytes.Buffer
+		zw := gzip.NewWriter(&compressed)
+		if _, err := zw.Write(plain.Bytes()); err != nil {
+			t.Fatalf("gzip write: %v", err)
+		}
+		if err := zw.Close(); err != nil {
+			t.Fatalf("gzip close: %v", err)
+		}
+		requirePackResponse(t, post(t, bytes.NewReader(compressed.Bytes()), "gzip"))
+	})
+
+	t.Run("CorruptGzipBodyRejected", func(t *testing.T) {
+		resp := post(t, strings.NewReader("not gzip at all"), "gzip")
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("corrupt gzip body: status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+		}
+	})
+}

--- a/pkg/backend/http/handler_parity_test.go
+++ b/pkg/backend/http/handler_parity_test.go
@@ -1,0 +1,320 @@
+package backend_test
+
+// Parity tests verifying that the go-git based smart-HTTP serving (info/refs
+// advertisement, upload-pack and receive-pack) behaves identically to the
+// canonical `git http-backend` CGI, as observed by a real git client over
+// wire protocol v0 and v2. Identical seed repositories are served by both
+// implementations and every operation is executed against both, comparing
+// the resulting refs and repository state.
+
+import (
+	"bytes"
+	"fmt"
+	"net/http/cgi"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	backendhttp "github.com/matrixhub-ai/hfd/pkg/backend/http"
+	"github.com/matrixhub-ai/hfd/pkg/storage"
+)
+
+// parityGit runs git with -c protocol.version=<ver> and returns stdout.
+func parityGit(t *testing.T, dir string, protoVer int, args ...string) string {
+	t.Helper()
+	full := append([]string{"-c", fmt.Sprintf("protocol.version=%d", protoVer)}, args...)
+	cmd := exec.CommandContext(t.Context(), "git", full...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(full, " "), err, stderr.String())
+	}
+	return string(out)
+}
+
+// lsRemoteLines returns the sorted pkt lines of `git ls-remote --symref <url>`,
+// which covers ref names, hashes, and the HEAD symref advertisement. Lines are
+// sorted because the wire protocol does not mandate an advertisement order.
+func lsRemoteLines(t *testing.T, protoVer int, url string) []string {
+	t.Helper()
+	var lines []string
+	for line := range strings.SplitSeq(parityGit(t, "", protoVer, "ls-remote", "--symref", url), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	sort.Strings(lines)
+	return lines
+}
+
+// forEachRefLines returns the sorted `git for-each-ref` lines of a repository.
+func forEachRefLines(t *testing.T, dir string) string {
+	t.Helper()
+	return runGitCmd(t, dir, "for-each-ref", "--format=%(objectname) %(objecttype) %(refname)")
+}
+
+// newHTTPBackendServer serves the bare repositories under root with the
+// canonical git http-backend CGI.
+func newHTTPBackendServer(t *testing.T, root string) string {
+	t.Helper()
+	execPath := strings.TrimSpace(runGitCmd(t, "", "--exec-path"))
+	backendPath := filepath.Join(execPath, "git-http-backend")
+	if _, err := os.Stat(backendPath); err != nil {
+		t.Skipf("git-http-backend not available: %v", err)
+	}
+	srv := httptest.NewServer(&cgi.Handler{
+		Path:       backendPath,
+		InheritEnv: []string{"PATH"},
+		Env: []string{
+			"GIT_PROJECT_ROOT=" + root,
+			"GIT_HTTP_EXPORT_ALL=1",
+		},
+	})
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// serveParityFixture creates one seed repository and serves byte-identical
+// copies with the production go-git handler and with git http-backend.
+// It returns the two repository URLs and the seeding work directory.
+type serveParityFixture struct {
+	goGitURL string // production handler URL for the repository
+	gitURL   string // git http-backend URL for the repository
+	work     string // work repository pushing to both servers
+}
+
+func newServeParityFixture(t *testing.T) *serveParityFixture {
+	t.Helper()
+	root := t.TempDir()
+
+	// Production go-git handler on its own storage root.
+	goGitStorage := storage.NewStorage(storage.WithRootDir(filepath.Join(root, "gogit")))
+	goGitRepo := filepath.Join(goGitStorage.RepositoriesDir(), "repo.git")
+	if err := os.MkdirAll(filepath.Dir(goGitRepo), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	runGitCmd(t, "", "init", "--bare", "--initial-branch=main", goGitRepo)
+	goGitServer := httptest.NewServer(backendhttp.NewHandler(backendhttp.WithStorage(goGitStorage)))
+	t.Cleanup(goGitServer.Close)
+
+	// git http-backend on a parallel root with an identical repository.
+	cgiRoot := filepath.Join(root, "cgi")
+	gitRepo := filepath.Join(cgiRoot, "repo.git")
+	if err := os.MkdirAll(cgiRoot, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	runGitCmd(t, "", "init", "--bare", "--initial-branch=main", gitRepo)
+	runGitCmd(t, gitRepo, "config", "http.receivepack", "true")
+	gitBase := newHTTPBackendServer(t, cgiRoot)
+
+	f := &serveParityFixture{
+		goGitURL: goGitServer.URL + "/repo.git",
+		gitURL:   gitBase + "/repo.git",
+		work:     filepath.Join(root, "work"),
+	}
+
+	// Seed both servers with the same commits, branches and tags. Pushing
+	// identical objects yields identical hashes on both sides.
+	runGitCmd(t, "", "init", "--initial-branch=main", f.work)
+	runGitCmd(t, f.work, "config", "user.email", "test@example.com")
+	runGitCmd(t, f.work, "config", "user.name", "Test User")
+	f.commit(t, "file.txt", "one\n", "c1")
+	f.commit(t, "file.txt", "two\n", "c2")
+	runGitCmd(t, f.work, "tag", "v1", "HEAD~1")
+	runGitCmd(t, f.work, "tag", "-a", "v2", "-m", "annotated v2")
+	runGitCmd(t, f.work, "checkout", "-b", "topic/nested")
+	f.commit(t, "file.txt", "topic\n", "topic change")
+	runGitCmd(t, f.work, "checkout", "main")
+	f.pushBoth(t, "refs/heads/main", "refs/heads/topic/nested", "refs/tags/v1", "refs/tags/v2")
+
+	return f
+}
+
+func (f *serveParityFixture) commit(t *testing.T, name, content, msg string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(f.work, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	runGitCmd(t, f.work, "add", ".")
+	runGitCmd(t, f.work, "commit", "-m", msg)
+}
+
+// pushBoth force-pushes the given refspecs to both servers so their state
+// stays identical.
+func (f *serveParityFixture) pushBoth(t *testing.T, refspecs ...string) {
+	t.Helper()
+	for _, url := range []string{f.goGitURL, f.gitURL} {
+		runGitCmd(t, f.work, append([]string{"push", "--force", url}, refspecs...)...)
+	}
+}
+
+func TestHTTPServeGitParity(t *testing.T) {
+	for _, protoVer := range []int{0, 2} {
+		t.Run(fmt.Sprintf("ProtocolV%d", protoVer), func(t *testing.T) {
+			f := newServeParityFixture(t)
+
+			t.Run("LsRemote", func(t *testing.T) {
+				goGitLines := lsRemoteLines(t, protoVer, f.goGitURL)
+				gitLines := lsRemoteLines(t, protoVer, f.gitURL)
+				if len(goGitLines) != len(gitLines) {
+					t.Fatalf("ls-remote line count mismatch:\ngo-git: %v\ngit:    %v", goGitLines, gitLines)
+				}
+				for i := range gitLines {
+					if goGitLines[i] != gitLines[i] {
+						t.Fatalf("ls-remote line %d mismatch:\ngo-git: %q\ngit:    %q", i, goGitLines[i], gitLines[i])
+					}
+				}
+			})
+
+			cloneDir := func(t *testing.T, url, name string) string {
+				dir := filepath.Join(t.TempDir(), name)
+				parityGit(t, "", protoVer, "clone", "--quiet", url, dir)
+				return dir
+			}
+
+			t.Run("Clone", func(t *testing.T) {
+				goGitClone := cloneDir(t, f.goGitURL, "gogit-clone")
+				gitClone := cloneDir(t, f.gitURL, "git-clone")
+
+				if got, want := forEachRefLines(t, goGitClone), forEachRefLines(t, gitClone); got != want {
+					t.Fatalf("cloned refs mismatch:\ngo-git served:\n%s\ngit served:\n%s", got, want)
+				}
+				runGitCmd(t, goGitClone, "fsck", "--full", "--strict")
+
+				goGitHead := runGitCmd(t, goGitClone, "symbolic-ref", "HEAD")
+				gitHead := runGitCmd(t, gitClone, "symbolic-ref", "HEAD")
+				if goGitHead != gitHead {
+					t.Fatalf("cloned HEAD mismatch: go-git served %q, git served %q", goGitHead, gitHead)
+				}
+			})
+
+			t.Run("IncrementalFetch", func(t *testing.T) {
+				goGitClone := cloneDir(t, f.goGitURL, "gogit-clone")
+				gitClone := cloneDir(t, f.gitURL, "git-clone")
+
+				f.commit(t, "file.txt", "three\n", "c3")
+				f.pushBoth(t, "refs/heads/main")
+
+				parityGit(t, goGitClone, protoVer, "fetch", "--quiet", "origin")
+				parityGit(t, gitClone, protoVer, "fetch", "--quiet", "origin")
+
+				got := runGitCmd(t, goGitClone, "rev-parse", "refs/remotes/origin/main")
+				want := runGitCmd(t, gitClone, "rev-parse", "refs/remotes/origin/main")
+				if got != want {
+					t.Fatalf("fetched main mismatch: go-git served %q, git served %q", got, want)
+				}
+			})
+
+			t.Run("PushCreateUpdateDelete", func(t *testing.T) {
+				// Create a branch and an annotated tag.
+				runGitCmd(t, f.work, "checkout", "-b", "parity-branch")
+				f.commit(t, "parity.txt", "parity\n", "parity commit")
+				runGitCmd(t, f.work, "tag", "-a", "parity-tag", "-m", "parity tag")
+				runGitCmd(t, f.work, "checkout", "main")
+				for _, url := range []string{f.goGitURL, f.gitURL} {
+					parityGit(t, f.work, protoVer, "push", url, "refs/heads/parity-branch", "refs/tags/parity-tag")
+				}
+				requireLsRemoteEqual(t, protoVer, f)
+
+				// Non-fast-forward force update.
+				runGitCmd(t, f.work, "checkout", "parity-branch")
+				runGitCmd(t, f.work, "reset", "--hard", "HEAD~1")
+				f.commit(t, "parity.txt", "rewritten\n", "rewritten")
+				runGitCmd(t, f.work, "checkout", "main")
+				for _, url := range []string{f.goGitURL, f.gitURL} {
+					parityGit(t, f.work, protoVer, "push", "--force", url, "refs/heads/parity-branch")
+				}
+				requireLsRemoteEqual(t, protoVer, f)
+
+				// Delete the branch and the tag.
+				for _, url := range []string{f.goGitURL, f.gitURL} {
+					parityGit(t, f.work, protoVer, "push", url, ":refs/heads/parity-branch", ":refs/tags/parity-tag")
+				}
+				requireLsRemoteEqual(t, protoVer, f)
+			})
+
+			t.Run("RejectedNonFastForward", func(t *testing.T) {
+				// A non-fast-forward push without --force must be rejected by
+				// both servers.
+				runGitCmd(t, f.work, "checkout", "-b", "reject-branch")
+				f.commit(t, "reject.txt", "a\n", "a")
+				for _, url := range []string{f.goGitURL, f.gitURL} {
+					parityGit(t, f.work, protoVer, "push", url, "refs/heads/reject-branch")
+				}
+				runGitCmd(t, f.work, "reset", "--hard", "HEAD~1")
+				f.commit(t, "reject.txt", "b\n", "b")
+				runGitCmd(t, f.work, "checkout", "main")
+
+				goGitErr := tryGit(t, f.work, protoVer, "push", f.goGitURL, "refs/heads/reject-branch")
+				gitErr := tryGit(t, f.work, protoVer, "push", f.gitURL, "refs/heads/reject-branch")
+				if (goGitErr == nil) != (gitErr == nil) {
+					t.Fatalf("non-fast-forward rejection diverged: go-git served err=%v, git served err=%v", goGitErr, gitErr)
+				}
+				requireLsRemoteEqual(t, protoVer, f)
+			})
+
+			t.Run("LargeNegotiationGzip", func(t *testing.T) {
+				// A fetch negotiation body over 1KiB makes the git client send
+				// the upload-pack request with Content-Encoding: gzip
+				// (remote-curl.c post_rpc). git http-backend transparently
+				// inflates it; the go-git served endpoint must do the same.
+				goGitClone := cloneDir(t, f.goGitURL, "gogit-clone")
+				gitClone := cloneDir(t, f.gitURL, "git-clone")
+
+				// Give the client plenty of distinct local-only commits so the
+				// negotiation sends large have batches unknown to the server.
+				for _, clone := range []string{goGitClone, gitClone} {
+					runGitCmd(t, clone, "config", "user.email", "test@example.com")
+					runGitCmd(t, clone, "config", "user.name", "Test User")
+					runGitCmd(t, clone, "checkout", "--quiet", "-b", "local-only")
+					for i := range 96 {
+						runGitCmd(t, clone, "commit", "--quiet", "--allow-empty", "-m", fmt.Sprintf("local %d", i))
+					}
+					runGitCmd(t, clone, "checkout", "--quiet", "main")
+				}
+
+				f.commit(t, "file.txt", "gzip trigger\n", "gzip trigger")
+				f.pushBoth(t, "refs/heads/main")
+
+				parityGit(t, goGitClone, protoVer, "fetch", "--quiet", "origin", "main")
+				parityGit(t, gitClone, protoVer, "fetch", "--quiet", "origin", "main")
+
+				got := runGitCmd(t, goGitClone, "rev-parse", "refs/remotes/origin/main")
+				want := runGitCmd(t, gitClone, "rev-parse", "refs/remotes/origin/main")
+				if got != want {
+					t.Fatalf("gzip negotiation fetch mismatch: go-git served %q, git served %q", got, want)
+				}
+			})
+		})
+	}
+}
+
+// requireLsRemoteEqual asserts both servers advertise identical refs.
+func requireLsRemoteEqual(t *testing.T, protoVer int, f *serveParityFixture) {
+	t.Helper()
+	goGitLines := strings.Join(lsRemoteLines(t, protoVer, f.goGitURL), "\n")
+	gitLines := strings.Join(lsRemoteLines(t, protoVer, f.gitURL), "\n")
+	if goGitLines != gitLines {
+		t.Fatalf("advertised refs diverged:\ngo-git served:\n%s\ngit served:\n%s", goGitLines, gitLines)
+	}
+}
+
+// tryGit runs git and returns the error instead of failing the test.
+func tryGit(t *testing.T, dir string, protoVer int, args ...string) error {
+	t.Helper()
+	full := append([]string{"-c", fmt.Sprintf("protocol.version=%d", protoVer)}, args...)
+	cmd := exec.CommandContext(t.Context(), "git", full...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git %s: %w\n%s", strings.Join(full, " "), err, out)
+	}
+	return nil
+}

--- a/pkg/repository/mirror.go
+++ b/pkg/repository/mirror.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/client"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
@@ -77,6 +78,9 @@ func getRemoteAdvertisedRefs(ctx context.Context, sourceURL string) (*transport.
 	sess, err := client.New(mirrorClientOptions...).Handshake(ctx, &transport.Request{
 		URL:     u,
 		Command: transport.UploadPackService,
+		// Prefer wire protocol v2 like the git binary: v0/v1 advertisements
+		// cannot express an unborn HEAD symref.
+		Protocol: protocol.V2,
 	})
 	if err != nil {
 		return nil, err
@@ -113,6 +117,11 @@ func GetRemoteDefaultBranch(ctx context.Context, sourceURL string) (string, erro
 func GetRemoteRefs(ctx context.Context, sourceURL string) (map[string]string, error) {
 	remoteRefs, err := getRemoteAdvertisedRefs(ctx, sourceURL)
 	if err != nil {
+		// Match `git ls-remote --refs`: an empty repository lists no refs
+		// instead of failing.
+		if errors.Is(err, transport.ErrEmptyRemoteRepository) {
+			return map[string]string{}, nil
+		}
 		return nil, fmt.Errorf("failed to list remote refs: %w", err)
 	}
 
@@ -143,7 +152,8 @@ func (r *Repository) mirrorRemote(url string) *git.Remote {
 // PushMirrorRefs pushes the specified refspecs to the destination URL.
 // Each refspec should be "+src:dst" for create/update or ":dst" for delete.
 // When prune is true, remote refs matching the refspecs that do not exist
-// locally are removed. Server progress messages are written to progress if non-nil.
+// locally are removed, matching `git push --prune` semantics.
+// Server progress messages are written to progress if non-nil.
 func (r *Repository) PushMirrorRefs(ctx context.Context, destURL string, refs []string, prune bool, progress io.Writer) error {
 	if len(refs) == 0 {
 		return nil
@@ -154,11 +164,23 @@ func (r *Repository) PushMirrorRefs(ctx context.Context, destURL string, refs []
 		specs = append(specs, gitconfig.RefSpec(refspec))
 	}
 
+	// Compute prune deletions ourselves instead of using go-git's
+	// PushOptions.Prune: its refspec reversal keeps the force prefix on the
+	// destination side, so local-existence lookups never match and every
+	// matching remote ref gets deleted. It also removes local refs that are
+	// missing on the remote, which push must never do.
+	if prune {
+		deletes, err := r.pushPruneRefSpecs(ctx, destURL, specs)
+		if err != nil {
+			return fmt.Errorf("failed to compute remote refs to prune: %w", err)
+		}
+		specs = append(specs, deletes...)
+	}
+
 	err := r.mirrorRemote(destURL).PushContext(ctx, &git.PushOptions{
 		RemoteName:    "mirror",
 		RemoteURL:     destURL,
 		RefSpecs:      specs,
-		Prune:         prune,
 		Progress:      progress,
 		ClientOptions: mirrorClientOptions,
 	})
@@ -167,6 +189,55 @@ func (r *Repository) PushMirrorRefs(ctx context.Context, destURL string, refs []
 	}
 
 	return nil
+}
+
+// pushPruneRefSpecs returns delete refspecs (":dst") for remote refs that
+// match the destination side of specs but no longer have a local counterpart,
+// like `git push --prune`.
+func (r *Repository) pushPruneRefSpecs(ctx context.Context, destURL string, specs []gitconfig.RefSpec) ([]gitconfig.RefSpec, error) {
+	remoteRefs, err := GetRemoteRefs(ctx, destURL)
+	if err != nil {
+		return nil, err
+	}
+	localRefs, err := r.Refs()
+	if err != nil {
+		return nil, err
+	}
+
+	// Reverse the specs manually (dst:src, force prefix stripped) so remote
+	// names can be mapped back to their local source refs.
+	reversed := make([]gitconfig.RefSpec, 0, len(specs))
+	for _, spec := range specs {
+		if spec.IsDelete() {
+			continue
+		}
+		raw := strings.TrimPrefix(spec.String(), "+")
+		src, dst, ok := strings.Cut(raw, ":")
+		if !ok {
+			dst = src
+		}
+		reversed = append(reversed, gitconfig.RefSpec(dst+":"+src))
+	}
+
+	var deletes []gitconfig.RefSpec
+	for remoteName := range remoteRefs {
+		name := plumbing.ReferenceName(remoteName)
+		matched, hasLocal := false, false
+		for _, rev := range reversed {
+			if !rev.Match(name) {
+				continue
+			}
+			matched = true
+			if _, ok := localRefs[rev.Dst(name).String()]; ok {
+				hasLocal = true
+				break
+			}
+		}
+		if matched && !hasLocal {
+			deletes = append(deletes, gitconfig.RefSpec(":"+remoteName))
+		}
+	}
+	return deletes, nil
 }
 
 // PullMirrorRefs fetches the specified refs from the sourceURL and updates the local mirror repository.

--- a/pkg/repository/mirror_parity_test.go
+++ b/pkg/repository/mirror_parity_test.go
@@ -1,0 +1,630 @@
+package repository
+
+// Parity tests verifying that the go-git based mirror operations behave
+// identically to the git subprocess commands they replaced:
+//
+//	GetRemoteDefaultBranch  <->  git ls-remote --symref <url> HEAD
+//	GetRemoteRefs           <->  git ls-remote --refs <url>
+//	PullMirrorRefs          <->  git fetch <url> --no-tags --progress +ref:ref... (+ prune)
+//	PushMirrorRefs          <->  git push [--prune] --no-tags --progress <url> <refspecs>
+//
+// Every scenario runs over two transports: the file transport and real
+// smart-HTTP served by `git http-backend` (the canonical server
+// implementation). Repositories written by go-git are additionally
+// cross-checked with the git binary (for-each-ref, fsck, cat-file) to prove
+// on-disk compatibility in both directions.
+
+import (
+	"bytes"
+	"fmt"
+	"net/http/cgi"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// gitOut runs git and returns its stdout, failing the test on error.
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=safe.bareRepository",
+		"GIT_CONFIG_VALUE_0=all",
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, stderr.String())
+	}
+	return string(out)
+}
+
+// gitTry runs git and returns an error instead of failing the test.
+func gitTry(t *testing.T, dir string, args ...string) error {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, out)
+	}
+	return nil
+}
+
+// gitLsRemoteRefs returns `git ls-remote --refs <url>` as a map of ref name to hash.
+func gitLsRemoteRefs(t *testing.T, url string) map[string]string {
+	t.Helper()
+	refs := make(map[string]string)
+	for line := range strings.SplitSeq(gitOut(t, "", "ls-remote", "--refs", url), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		hash, name, ok := strings.Cut(line, "\t")
+		if !ok {
+			t.Fatalf("unexpected ls-remote line: %q", line)
+		}
+		refs[name] = hash
+	}
+	return refs
+}
+
+// gitSymrefHead returns the branch `git ls-remote --symref <url> HEAD` reports
+// for HEAD, or "" if git does not report a symref.
+func gitSymrefHead(t *testing.T, url string) string {
+	t.Helper()
+	for line := range strings.SplitSeq(gitOut(t, "", "ls-remote", "--symref", url, "HEAD"), "\n") {
+		if ref, ok := strings.CutSuffix(line, "\tHEAD"); ok {
+			if branch, ok := strings.CutPrefix(ref, "ref: refs/heads/"); ok {
+				return branch
+			}
+		}
+	}
+	return ""
+}
+
+// gitCloneHeadBranch clones url with the git binary and returns the branch
+// HEAD points at, i.e. the default branch a real git client ends up on.
+func gitCloneHeadBranch(t *testing.T, url string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "head-clone")
+	runGit(t, "", "clone", "--quiet", url, dir)
+	head, err := os.ReadFile(filepath.Join(dir, ".git", "HEAD"))
+	if err != nil {
+		t.Fatalf("read cloned HEAD: %v", err)
+	}
+	return strings.TrimPrefix(strings.TrimSpace(string(head)), "ref: refs/heads/")
+}
+
+// gitLocalRefs returns all refs of a local repository as seen by the git
+// binary via for-each-ref.
+func gitLocalRefs(t *testing.T, repoPath string) map[string]string {
+	t.Helper()
+	refs := make(map[string]string)
+	for line := range strings.SplitSeq(gitOut(t, repoPath, "for-each-ref", "--format=%(objectname) %(refname)"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		hash, name, ok := strings.Cut(line, " ")
+		if !ok {
+			t.Fatalf("unexpected for-each-ref line: %q", line)
+		}
+		refs[name] = hash
+	}
+	return refs
+}
+
+// gitFsck verifies object connectivity and integrity with the git binary.
+func gitFsck(t *testing.T, repoPath string) {
+	t.Helper()
+	runGit(t, repoPath, "fsck", "--full", "--strict")
+}
+
+// requireSameRefs asserts two ref maps are identical.
+func requireSameRefs(t *testing.T, label string, got, want map[string]string) {
+	t.Helper()
+	for name, wantHash := range want {
+		gotHash, ok := got[name]
+		if !ok {
+			t.Fatalf("%s: missing ref %s (want %s); got %v", label, name, wantHash, got)
+		}
+		if gotHash != wantHash {
+			t.Fatalf("%s: ref %s = %s, want %s", label, name, gotHash, wantHash)
+		}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("%s: extra refs present: got %v, want %v", label, got, want)
+	}
+}
+
+// legacyPullMirrorRefs reproduces the pre-go-git PullMirrorRefs implementation
+// with git subprocesses: fetch with explicit forced refspecs, then prune
+// local refs that are not in the desired set.
+func legacyPullMirrorRefs(t *testing.T, repoPath, sourceURL string, refs []string) {
+	t.Helper()
+	args := []string{"fetch", sourceURL, "--no-tags", "--progress"}
+	for _, ref := range refs {
+		args = append(args, "+"+ref+":"+ref)
+	}
+	runGit(t, repoPath, args...)
+
+	desired := make(map[string]bool, len(refs))
+	for _, ref := range refs {
+		desired[ref] = true
+	}
+	for name := range gitLocalRefs(t, repoPath) {
+		if !desired[name] {
+			runGit(t, repoPath, "update-ref", "-d", name)
+		}
+	}
+}
+
+// legacyPushMirrorRefs reproduces the pre-go-git PushMirrorRefs implementation
+// with git subprocesses.
+func legacyPushMirrorRefs(t *testing.T, repoPath, destURL string, refspecs []string, prune bool) {
+	t.Helper()
+	args := []string{"push"}
+	if prune {
+		args = append(args, "--prune")
+	}
+	args = append(args, "--no-tags", "--progress", destURL)
+	args = append(args, refspecs...)
+	runGit(t, repoPath, args...)
+}
+
+// newGitHTTPBackend serves every bare repository under root over smart HTTP
+// using the canonical `git http-backend` CGI, and returns the base URL.
+func newGitHTTPBackend(t *testing.T, root string) string {
+	t.Helper()
+	execPath := strings.TrimSpace(gitOut(t, "", "--exec-path"))
+	backend := filepath.Join(execPath, "git-http-backend")
+	if _, err := os.Stat(backend); err != nil {
+		t.Skipf("git-http-backend not available: %v", err)
+	}
+	srv := httptest.NewServer(&cgi.Handler{
+		Path:       backend,
+		InheritEnv: []string{"PATH"},
+		Env: []string{
+			"GIT_PROJECT_ROOT=" + root,
+			"GIT_HTTP_EXPORT_ALL=1",
+		},
+	})
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// parityTransport maps a bare repository path under root to a URL for one transport.
+type parityTransport struct {
+	name string
+	url  func(bareRepoPath string) string
+}
+
+// parityTransports returns the file and smart-HTTP transports for repositories under root.
+// Bare repositories that should accept pushes over HTTP need http.receivepack=true.
+func parityTransports(t *testing.T, root string) []parityTransport {
+	t.Helper()
+	base := newGitHTTPBackend(t, root)
+	return []parityTransport{
+		{name: "file", url: func(p string) string { return p }},
+		{name: "http", url: func(p string) string {
+			rel, err := filepath.Rel(root, p)
+			if err != nil {
+				t.Fatalf("rel %s: %v", p, err)
+			}
+			return base + "/" + filepath.ToSlash(rel)
+		}},
+	}
+}
+
+// initParityWork creates a non-bare work repository for building fixtures.
+func initParityWork(t *testing.T, path string) {
+	t.Helper()
+	runGit(t, "", "init", "--initial-branch=main", path)
+	runGit(t, path, "config", "user.email", "test@example.com")
+	runGit(t, path, "config", "user.name", "Test User")
+}
+
+// commitFile writes content to name in work and commits it on the current branch.
+func commitFile(t *testing.T, work, name, content, msg string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(work, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	runGit(t, work, "add", ".")
+	runGit(t, work, "commit", "-m", msg)
+}
+
+// buildParityUpstream creates a bare upstream with branches main and
+// topic/nested, a lightweight tag v1 and an annotated tag v2, plus the work
+// clone used to evolve it.
+func buildParityUpstream(t *testing.T, root string) (bare, work string) {
+	t.Helper()
+	bare = filepath.Join(root, "upstream.git")
+	runGit(t, "", "init", "--bare", "--initial-branch=main", bare)
+
+	work = filepath.Join(root, "work")
+	initParityWork(t, work)
+	commitFile(t, work, "file.txt", "one\n", "c1")
+	commitFile(t, work, "file.txt", "two\n", "c2")
+	runGit(t, work, "remote", "add", "origin", bare)
+	runGit(t, work, "push", "-u", "origin", "main")
+
+	runGit(t, work, "tag", "v1", "HEAD~1")
+	runGit(t, work, "tag", "-a", "v2", "-m", "annotated v2")
+	runGit(t, work, "push", "origin", "v1", "v2")
+
+	runGit(t, work, "checkout", "-b", "topic/nested")
+	commitFile(t, work, "file.txt", "topic\n", "topic change")
+	runGit(t, work, "push", "-u", "origin", "topic/nested")
+	runGit(t, work, "checkout", "main")
+
+	return bare, work
+}
+
+func TestGitParityGetRemoteRefs(t *testing.T) {
+	ctx := t.Context()
+	root := t.TempDir()
+	bare, _ := buildParityUpstream(t, root)
+
+	empty := filepath.Join(root, "empty.git")
+	runGit(t, "", "init", "--bare", "--initial-branch=main", empty)
+
+	for _, tr := range parityTransports(t, root) {
+		t.Run(tr.name, func(t *testing.T) {
+			url := tr.url(bare)
+			got, err := GetRemoteRefs(ctx, url)
+			if err != nil {
+				t.Fatalf("GetRemoteRefs: %v", err)
+			}
+			requireSameRefs(t, "GetRemoteRefs vs git ls-remote --refs", got, gitLsRemoteRefs(t, url))
+
+			// The fixture must exercise annotated tags: ls-remote --refs
+			// reports the tag object, not the peeled commit, and no ^{} entries.
+			if typ := strings.TrimSpace(gitOut(t, bare, "cat-file", "-t", got["refs/tags/v2"])); typ != "tag" {
+				t.Fatalf("refs/tags/v2 should resolve to a tag object, got %q", typ)
+			}
+
+			t.Run("EmptyRepository", func(t *testing.T) {
+				url := tr.url(empty)
+				got, err := GetRemoteRefs(ctx, url)
+				if err != nil {
+					t.Fatalf("GetRemoteRefs on empty repository: %v", err)
+				}
+				requireSameRefs(t, "empty repository refs", got, gitLsRemoteRefs(t, url))
+			})
+
+			t.Run("MissingRepository", func(t *testing.T) {
+				url := tr.url(filepath.Join(root, "does-not-exist.git"))
+				if _, err := GetRemoteRefs(ctx, url); err == nil {
+					t.Fatalf("GetRemoteRefs should fail for missing repository, like git ls-remote")
+				}
+				if err := gitTry(t, "", "ls-remote", "--refs", url); err == nil {
+					t.Fatalf("git ls-remote unexpectedly succeeded for missing repository")
+				}
+			})
+		})
+	}
+}
+
+func TestGitParityGetRemoteDefaultBranch(t *testing.T) {
+	ctx := t.Context()
+	root := t.TempDir()
+
+	// A repository whose default branch differs from any client-side default.
+	bare := filepath.Join(root, "custom.git")
+	runGit(t, "", "init", "--bare", "--initial-branch=parity-branch", bare)
+	work := filepath.Join(root, "work")
+	initParityWork(t, work)
+	runGit(t, work, "checkout", "-b", "parity-branch")
+	commitFile(t, work, "file.txt", "content\n", "c1")
+	// A second branch that sorts before the default one, to catch
+	// implementations that guess instead of honoring the HEAD symref.
+	runGit(t, work, "checkout", "-b", "aaa-first")
+	commitFile(t, work, "file.txt", "other\n", "c2")
+	runGit(t, work, "remote", "add", "origin", bare)
+	runGit(t, work, "push", "origin", "parity-branch", "aaa-first")
+
+	emptyBare := filepath.Join(root, "empty.git")
+	runGit(t, "", "init", "--bare", "--initial-branch=unborn-branch", emptyBare)
+
+	// A repository whose HEAD points at an unborn branch while other refs
+	// exist, as seen on hub repositories before the default branch is born.
+	unbornBare := filepath.Join(root, "unborn.git")
+	runGit(t, "", "init", "--bare", "--initial-branch=unborn-branch", unbornBare)
+	unbornWork := filepath.Join(root, "unborn-work")
+	initParityWork(t, unbornWork)
+	runGit(t, unbornWork, "checkout", "-b", "side")
+	commitFile(t, unbornWork, "file.txt", "side\n", "side commit")
+	runGit(t, unbornWork, "remote", "add", "origin", unbornBare)
+	runGit(t, unbornWork, "push", "origin", "side")
+
+	for _, tr := range parityTransports(t, root) {
+		t.Run(tr.name, func(t *testing.T) {
+			url := tr.url(bare)
+			got, err := GetRemoteDefaultBranch(ctx, url)
+			if err != nil {
+				t.Fatalf("GetRemoteDefaultBranch: %v", err)
+			}
+			if want := gitSymrefHead(t, url); got != want {
+				t.Fatalf("default branch = %q, git ls-remote --symref reports %q", got, want)
+			}
+			if want := gitCloneHeadBranch(t, url); got != want {
+				t.Fatalf("default branch = %q, git clone checks out %q", got, want)
+			}
+
+			t.Run("EmptyRepository", func(t *testing.T) {
+				url := tr.url(emptyBare)
+				// Parity: `git ls-remote --symref` reports no symref for an
+				// empty repository, so the legacy subprocess implementation
+				// failed here too. The error must be preserved, not a bogus
+				// branch invented.
+				if want := gitSymrefHead(t, url); want != "" {
+					t.Fatalf("expected git ls-remote --symref to report no symref, got %q", want)
+				}
+				if got, err := GetRemoteDefaultBranch(ctx, url); err == nil {
+					// Resolving the unborn HEAD is an acceptable improvement
+					// over the legacy behavior, but only if it matches what a
+					// real git clone checks out.
+					if want := gitCloneHeadBranch(t, url); got != want {
+						t.Fatalf("default branch = %q, git clone checks out %q", got, want)
+					}
+				}
+			})
+
+			t.Run("UnbornHEADWithOtherRefs", func(t *testing.T) {
+				url := tr.url(unbornBare)
+				// Parity: `git ls-remote --symref` reports no symref when HEAD
+				// is unborn, so the legacy subprocess implementation errored
+				// here as well. Failing is acceptable; resolving a branch is
+				// an improvement but must match what `git clone` checks out.
+				if want := gitSymrefHead(t, url); want != "" {
+					t.Fatalf("expected git ls-remote --symref to report no symref, got %q", want)
+				}
+				if got, err := GetRemoteDefaultBranch(ctx, url); err == nil {
+					if want := gitCloneHeadBranch(t, url); got != want {
+						t.Fatalf("default branch = %q, git clone checks out %q", got, want)
+					}
+				}
+			})
+		})
+	}
+}
+
+func TestGitParityPullMirrorRefs(t *testing.T) {
+	ctx := t.Context()
+
+	type stage struct {
+		name   string
+		mutate func(t *testing.T, work string)
+		refs   []string
+	}
+	allRefs := []string{"refs/heads/main", "refs/heads/topic/nested", "refs/tags/v1", "refs/tags/v2"}
+	stages := []stage{
+		{
+			name:   "InitialSync",
+			mutate: func(t *testing.T, work string) {},
+			refs:   allRefs,
+		},
+		{
+			name: "FastForward",
+			mutate: func(t *testing.T, work string) {
+				commitFile(t, work, "file.txt", "three\n", "c3")
+				runGit(t, work, "push", "origin", "main")
+			},
+			refs: allRefs,
+		},
+		{
+			name: "ForcedUpdate",
+			mutate: func(t *testing.T, work string) {
+				// Rewind main and move the annotated tag: both are
+				// non-fast-forward updates requiring forced refspecs.
+				runGit(t, work, "reset", "--hard", "HEAD~2")
+				commitFile(t, work, "file.txt", "rewritten\n", "rewritten")
+				runGit(t, work, "push", "--force", "origin", "main")
+				runGit(t, work, "tag", "-f", "-a", "v2", "-m", "moved v2")
+				runGit(t, work, "push", "--force", "origin", "v2")
+			},
+			refs: allRefs,
+		},
+		{
+			name: "PruneUnlistedRefs",
+			mutate: func(t *testing.T, work string) {
+				runGit(t, work, "push", "origin", "--delete", "topic/nested")
+			},
+			// topic/nested is gone upstream and v1 dropped by the filter:
+			// both must be pruned locally.
+			refs: []string{"refs/heads/main", "refs/tags/v2"},
+		},
+	}
+
+	for _, trName := range []string{"file", "http"} {
+		t.Run(trName, func(t *testing.T) {
+			root := t.TempDir()
+			bare, work := buildParityUpstream(t, root)
+			var tr parityTransport
+			for _, cand := range parityTransports(t, root) {
+				if cand.name == trName {
+					tr = cand
+				}
+			}
+			sourceURL := tr.url(bare)
+
+			goGitMirror := filepath.Join(root, "gogit-mirror.git")
+			repo, err := InitMirror(ctx, goGitMirror, sourceURL)
+			if err != nil {
+				t.Fatalf("init go-git mirror: %v", err)
+			}
+			legacyMirror := filepath.Join(root, "legacy-mirror.git")
+			runGit(t, "", "init", "--bare", "--initial-branch=main", legacyMirror)
+
+			for _, st := range stages {
+				t.Run(st.name, func(t *testing.T) {
+					st.mutate(t, work)
+
+					if err := repo.PullMirrorRefs(ctx, sourceURL, st.refs, nil); err != nil {
+						t.Fatalf("PullMirrorRefs: %v", err)
+					}
+					legacyPullMirrorRefs(t, legacyMirror, sourceURL, st.refs)
+
+					want := gitLocalRefs(t, legacyMirror)
+					requireSameRefs(t, "go-git mirror vs git fetch mirror (git view)", gitLocalRefs(t, goGitMirror), want)
+
+					goGitView, err := repo.Refs()
+					if err != nil {
+						t.Fatalf("Refs: %v", err)
+					}
+					requireSameRefs(t, "go-git Refs() vs git for-each-ref", goGitView, want)
+
+					gitFsck(t, goGitMirror)
+					for name, hash := range want {
+						// Every synced object must be fully readable by the git binary.
+						gitOut(t, goGitMirror, "rev-list", "--objects", hash)
+						if strings.HasPrefix(name, "refs/tags/v2") {
+							if typ := strings.TrimSpace(gitOut(t, goGitMirror, "cat-file", "-t", hash)); typ != "tag" {
+								t.Fatalf("annotated tag %s fetched as %q, want tag object", name, typ)
+							}
+						}
+					}
+				})
+			}
+
+			t.Run("MissingRemoteRef", func(t *testing.T) {
+				refs := []string{"refs/heads/main", "refs/heads/gone"}
+				err := repo.PullMirrorRefs(ctx, sourceURL, refs, nil)
+				legacyErr := func() error {
+					args := []string{"fetch", sourceURL, "--no-tags", "--progress"}
+					for _, ref := range refs {
+						args = append(args, "+"+ref+":"+ref)
+					}
+					return gitTry(t, legacyMirror, args...)
+				}()
+				if (err == nil) != (legacyErr == nil) {
+					t.Fatalf("missing ref behavior diverged: go-git err=%v, git err=%v", err, legacyErr)
+				}
+			})
+		})
+	}
+}
+
+func TestGitParityPushMirrorRefs(t *testing.T) {
+	ctx := t.Context()
+
+	// The production wildcard refspecs used by mirror push with prune.
+	wildcard := []string{"+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*"}
+
+	type stage struct {
+		name     string
+		mutate   func(t *testing.T, work, localBare string)
+		refspecs []string
+		prune    bool
+	}
+	stages := []stage{
+		{
+			name:     "InitialWildcardPush",
+			mutate:   func(t *testing.T, work, localBare string) {},
+			refspecs: wildcard,
+			prune:    true,
+		},
+		{
+			name: "FastForward",
+			mutate: func(t *testing.T, work, localBare string) {
+				commitFile(t, work, "file.txt", "three\n", "c3")
+				runGit(t, work, "push", "origin", "main")
+			},
+			refspecs: wildcard,
+			prune:    true,
+		},
+		{
+			name: "ForcedUpdate",
+			mutate: func(t *testing.T, work, localBare string) {
+				runGit(t, work, "reset", "--hard", "HEAD~2")
+				commitFile(t, work, "file.txt", "rewritten\n", "rewritten")
+				runGit(t, work, "push", "--force", "origin", "main")
+				runGit(t, work, "tag", "-f", "-a", "v2", "-m", "moved v2")
+				runGit(t, work, "push", "--force", "origin", "v2")
+			},
+			refspecs: wildcard,
+			prune:    true,
+		},
+		{
+			name: "PruneDeletedBranch",
+			mutate: func(t *testing.T, work, localBare string) {
+				runGit(t, work, "push", "origin", "--delete", "topic/nested")
+			},
+			refspecs: wildcard,
+			prune:    true,
+		},
+		{
+			name:     "ExplicitDelete",
+			mutate:   func(t *testing.T, work, localBare string) {},
+			refspecs: []string{":refs/tags/v1"},
+			prune:    false,
+		},
+		{
+			name: "ExplicitRefspecs",
+			mutate: func(t *testing.T, work, localBare string) {
+				commitFile(t, work, "file.txt", "explicit\n", "explicit")
+				runGit(t, work, "push", "origin", "main")
+			},
+			refspecs: []string{"+refs/heads/main:refs/heads/main", "+refs/tags/v2:refs/tags/v2"},
+			prune:    false,
+		},
+	}
+
+	for _, trName := range []string{"file", "http"} {
+		t.Run(trName, func(t *testing.T) {
+			root := t.TempDir()
+			// The local repository whose refs are mirrored outward; the
+			// upstream fixture doubles as that local repository here.
+			localBare, work := buildParityUpstream(t, root)
+			repo, err := Open(localBare)
+			if err != nil {
+				t.Fatalf("open local repository: %v", err)
+			}
+
+			goGitDest := filepath.Join(root, "gogit-dest.git")
+			legacyDest := filepath.Join(root, "legacy-dest.git")
+			for _, dest := range []string{goGitDest, legacyDest} {
+				runGit(t, "", "init", "--bare", "--initial-branch=main", dest)
+				// Allow anonymous pushes through git http-backend.
+				runGit(t, dest, "config", "http.receivepack", "true")
+			}
+
+			var tr parityTransport
+			for _, cand := range parityTransports(t, root) {
+				if cand.name == trName {
+					tr = cand
+				}
+			}
+
+			for _, st := range stages {
+				t.Run(st.name, func(t *testing.T) {
+					st.mutate(t, work, localBare)
+
+					if err := repo.PushMirrorRefs(ctx, tr.url(goGitDest), st.refspecs, st.prune, nil); err != nil {
+						t.Fatalf("PushMirrorRefs: %v", err)
+					}
+					legacyPushMirrorRefs(t, localBare, tr.url(legacyDest), st.refspecs, st.prune)
+
+					want := gitLocalRefs(t, legacyDest)
+					requireSameRefs(t, "go-git push dest vs git push dest", gitLocalRefs(t, goGitDest), want)
+
+					gitFsck(t, goGitDest)
+					if hash, ok := want["refs/tags/v2"]; ok {
+						if typ := strings.TrimSpace(gitOut(t, goGitDest, "cat-file", "-t", hash)); typ != "tag" {
+							t.Fatalf("annotated tag pushed as %q, want tag object", typ)
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/pkg/repository/mirror_refs_test.go
+++ b/pkg/repository/mirror_refs_test.go
@@ -213,6 +213,91 @@ func TestPushMirrorRefs(t *testing.T) {
 	}
 }
 
+func TestPushMirrorRefsPrune(t *testing.T) {
+	ctx := t.Context()
+	root := t.TempDir()
+
+	local, work := buildParityUpstream(t, root)
+	repo, err := Open(local)
+	if err != nil {
+		t.Fatalf("open local repository: %v", err)
+	}
+
+	wildcard := []string{"+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*"}
+
+	destA := filepath.Join(root, "dest-a.git")
+	runGit(t, "", "init", "--bare", "--initial-branch=main", destA)
+
+	// pushPrune pushes with prune=true and asserts local refs are never
+	// touched: go-git's own prune implementation deleted local refs that
+	// were missing on the remote.
+	pushPrune := func(t *testing.T, dest string, refspecs []string) {
+		t.Helper()
+		before := gitLocalRefs(t, local)
+		if err := repo.PushMirrorRefs(ctx, dest, refspecs, true, nil); err != nil {
+			t.Fatalf("PushMirrorRefs with prune: %v", err)
+		}
+		requireSameRefs(t, "local refs must survive a prune push", gitLocalRefs(t, local), before)
+	}
+
+	t.Run("InitialPushToEmptyDestination", func(t *testing.T) {
+		// destA is empty here: prune must tolerate an empty remote.
+		pushPrune(t, destA, wildcard)
+		requireSameRefs(t, "destination after initial push", gitLocalRefs(t, destA), gitLocalRefs(t, local))
+	})
+
+	t.Run("RepushKeepsExistingRefs", func(t *testing.T) {
+		// Regression: a second pruning push used to delete every remote ref
+		// that still existed locally.
+		commitFile(t, work, "file.txt", "advance\n", "advance")
+		runGit(t, work, "push", "origin", "main")
+
+		pushPrune(t, destA, wildcard)
+		requireSameRefs(t, "destination after repush", gitLocalRefs(t, destA), gitLocalRefs(t, local))
+	})
+
+	t.Run("MappedWildcardRefspec", func(t *testing.T) {
+		destB := filepath.Join(root, "dest-b.git")
+		runGit(t, "", "init", "--bare", "--initial-branch=main", destB)
+
+		mapped := []string{"+refs/heads/*:refs/mirror/*"}
+		pushPrune(t, destB, mapped)
+
+		localRefs := gitLocalRefs(t, local)
+		want := map[string]string{
+			"refs/mirror/main":         localRefs["refs/heads/main"],
+			"refs/mirror/topic/nested": localRefs["refs/heads/topic/nested"],
+		}
+		requireSameRefs(t, "mapped destination refs", gitLocalRefs(t, destB), want)
+
+		// A destination ref outside the refspec patterns must survive prune.
+		runGit(t, destB, "update-ref", "refs/heads/standalone", localRefs["refs/heads/main"])
+
+		runGit(t, local, "update-ref", "-d", "refs/heads/topic/nested")
+		pushPrune(t, destB, mapped)
+
+		want = map[string]string{
+			"refs/mirror/main":     localRefs["refs/heads/main"],
+			"refs/heads/standalone": localRefs["refs/heads/main"],
+		}
+		requireSameRefs(t, "mapped destination refs after prune", gitLocalRefs(t, destB), want)
+	})
+
+	t.Run("PrunesRefsDeletedLocally", func(t *testing.T) {
+		// topic/nested was deleted above; also drop a tag. Both must be
+		// pruned from destA while an unrelated destination ref survives.
+		runGit(t, local, "update-ref", "-d", "refs/tags/v1")
+		keepHash := gitLocalRefs(t, local)["refs/heads/main"]
+		runGit(t, destA, "update-ref", "refs/keep/x", keepHash)
+
+		pushPrune(t, destA, wildcard)
+
+		want := gitLocalRefs(t, local)
+		want["refs/keep/x"] = keepHash
+		requireSameRefs(t, "destination after pruning deleted refs", gitLocalRefs(t, destA), want)
+	})
+}
+
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.CommandContext(t.Context(), "git", args...)

--- a/pkg/repository/mirror_refs_test.go
+++ b/pkg/repository/mirror_refs_test.go
@@ -277,7 +277,7 @@ func TestPushMirrorRefsPrune(t *testing.T) {
 		pushPrune(t, destB, mapped)
 
 		want = map[string]string{
-			"refs/mirror/main":     localRefs["refs/heads/main"],
+			"refs/mirror/main":      localRefs["refs/heads/main"],
 			"refs/heads/standalone": localRefs["refs/heads/main"],
 		}
 		requireSameRefs(t, "mapped destination refs after prune", gitLocalRefs(t, destB), want)

--- a/pkg/repository/serve.go
+++ b/pkg/repository/serve.go
@@ -43,6 +43,12 @@ func (r *Repository) Stateless(ctx context.Context, output io.Writer, input io.R
 	}
 }
 
+// maxUploadPackRequestSize caps a buffered v0 upload-pack request body,
+// matching git http-backend's http.maxRequestBuffer default. Negotiation
+// bodies are small (wants plus replayed haves); the cap guards against
+// oversized or decompression-bomb payloads on this unauthenticated path.
+const maxUploadPackRequestSize = 10 << 20
+
 // serveStatelessUploadPackV0 serves one stateless-RPC git-upload-pack request
 // for wire protocol v0/v1.
 //
@@ -53,9 +59,12 @@ func (r *Repository) Stateless(ctx context.Context, output io.Writer, input io.R
 // without "done" are therefore answered here with a single ACK/NAK round,
 // exactly like git http-backend; final rounds are delegated to go-git.
 func (r *Repository) serveStatelessUploadPackV0(ctx context.Context, output io.Writer, input io.Reader, gitProtocol string) error {
-	body, err := io.ReadAll(input)
+	body, err := io.ReadAll(io.LimitReader(input, maxUploadPackRequestSize+1))
 	if err != nil {
 		return fmt.Errorf("reading upload-pack request: %w", err)
+	}
+	if len(body) > maxUploadPackRequestSize {
+		return fmt.Errorf("upload-pack request larger than maximum size %d", maxUploadPackRequestSize)
 	}
 
 	if uploadPackRequestHasDone(body) {
@@ -87,7 +96,8 @@ func uploadPackRequestHasDone(body []byte) bool {
 // serveUploadPackNegotiationRound answers a single v0/v1 negotiation round
 // that did not conclude with "done": common objects are acknowledged
 // according to the negotiated multi_ack capability and the round is closed
-// with NAK, mirroring git upload-pack's get_common_commits.
+// with NAK. Unlike C git, the NAK is sent even when commons were found;
+// fetch-pack treats NAK as the round terminator either way.
 func (r *Repository) serveUploadPackNegotiationRound(body io.Reader, output io.Writer) error {
 	rd := bufio.NewReader(body)
 

--- a/pkg/repository/serve.go
+++ b/pkg/repository/serve.go
@@ -1,11 +1,16 @@
 package repository
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"strings"
 
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/utils/ioutil"
@@ -20,10 +25,13 @@ func (r *Repository) Stateless(ctx context.Context, output io.Writer, input io.R
 	in := io.NopCloser(input)
 	switch service {
 	case GitUploadPack:
-		return transport.UploadPack(ctx, r.repo.Storer, in, w, &transport.UploadPackRequest{
-			GitProtocol:  gitProtocol,
-			StatelessRPC: true,
-		})
+		if transport.ProtocolVersion(gitProtocol) == protocol.V2 {
+			return transport.UploadPack(ctx, r.repo.Storer, in, w, &transport.UploadPackRequest{
+				GitProtocol:  gitProtocol,
+				StatelessRPC: true,
+			})
+		}
+		return r.serveStatelessUploadPackV0(ctx, output, input, gitProtocol)
 	case GitReceivePack:
 		return transport.ReceivePack(ctx, r.repo.Storer, in, w, &transport.ReceivePackRequest{
 			GitProtocol:  gitProtocol,
@@ -33,6 +41,109 @@ func (r *Repository) Stateless(ctx context.Context, output io.Writer, input io.R
 	default:
 		return fmt.Errorf("unsupported service: %s", service)
 	}
+}
+
+// serveStatelessUploadPackV0 serves one stateless-RPC git-upload-pack request
+// for wire protocol v0/v1.
+//
+// In stateless RPC every negotiation round arrives as a separate request
+// (`git upload-pack --stateless-rpc` exits after each round), but go-git's
+// transport.UploadPack keeps reading rounds from the same request body until
+// the client sends "done" and fails with EOF on intermediate rounds. Requests
+// without "done" are therefore answered here with a single ACK/NAK round,
+// exactly like git http-backend; final rounds are delegated to go-git.
+func (r *Repository) serveStatelessUploadPackV0(ctx context.Context, output io.Writer, input io.Reader, gitProtocol string) error {
+	body, err := io.ReadAll(input)
+	if err != nil {
+		return fmt.Errorf("reading upload-pack request: %w", err)
+	}
+
+	if uploadPackRequestHasDone(body) {
+		return transport.UploadPack(ctx, r.repo.Storer, io.NopCloser(bytes.NewReader(body)), ioutil.WriteNopCloser(output), &transport.UploadPackRequest{
+			GitProtocol:  gitProtocol,
+			StatelessRPC: true,
+		})
+	}
+
+	return r.serveUploadPackNegotiationRound(bytes.NewReader(body), output)
+}
+
+// uploadPackRequestHasDone reports whether an upload-pack request body
+// contains the final "done" pkt-line. Upload-pack requests consist solely of
+// pkt-lines (wants, shallows, haves), never raw pack data.
+func uploadPackRequestHasDone(body []byte) bool {
+	rd := bufio.NewReader(bytes.NewReader(body))
+	for {
+		_, line, err := pktline.ReadLine(rd)
+		if err != nil {
+			return false
+		}
+		if strings.TrimSuffix(string(line), "\n") == "done" {
+			return true
+		}
+	}
+}
+
+// serveUploadPackNegotiationRound answers a single v0/v1 negotiation round
+// that did not conclude with "done": common objects are acknowledged
+// according to the negotiated multi_ack capability and the round is closed
+// with NAK, mirroring git upload-pack's get_common_commits.
+func (r *Repository) serveUploadPackNegotiationRound(body io.Reader, output io.Writer) error {
+	rd := bufio.NewReader(body)
+
+	l, _, err := pktline.PeekLine(rd)
+	if err != nil {
+		return fmt.Errorf("peeking upload-pack request: %w", err)
+	}
+	// A lone flush packet is a probe request; there is nothing to answer.
+	if l == pktline.Flush {
+		return nil
+	}
+
+	upreq := &packp.UploadRequest{}
+	if err := upreq.Decode(rd); err != nil {
+		return fmt.Errorf("decoding upload-request: %w", err)
+	}
+	var uphav packp.UploadHaves
+	if err := uphav.Decode(rd); err != nil {
+		return fmt.Errorf("decoding upload-haves: %w", err)
+	}
+
+	multiAckDetailed := upreq.Capabilities.Supports(capability.MultiACKDetailed)
+	multiAck := upreq.Capabilities.Supports(capability.MultiACK)
+
+	var acks []packp.ACK
+	for _, h := range uphav.Haves {
+		if r.repo.Storer.HasEncodedObject(h) != nil {
+			continue
+		}
+		switch {
+		case multiAckDetailed:
+			acks = append(acks, packp.ACK{Hash: h, Status: packp.ACKCommon})
+		case multiAck:
+			acks = append(acks, packp.ACK{Hash: h, Status: packp.ACKContinue})
+		default:
+			// Single-ack mode acknowledges only the first common object.
+			acks = append(acks, packp.ACK{Hash: h})
+		}
+		if !multiAck && !multiAckDetailed {
+			break
+		}
+	}
+
+	if len(acks) > 0 {
+		if err := (&packp.ServerResponse{ACKs: acks}).Encode(output); err != nil {
+			return fmt.Errorf("sending acks: %w", err)
+		}
+		if !multiAck && !multiAckDetailed {
+			return nil
+		}
+	}
+	// Close the round: the client responds with more haves or "done".
+	if _, err := pktline.WriteString(output, "NAK\n"); err != nil {
+		return fmt.Errorf("sending nak: %w", err)
+	}
+	return nil
 }
 
 // AdvertiseRefs writes the smart-HTTP /info/refs advertisement for the given

--- a/pkg/repository/serve_stateless_test.go
+++ b/pkg/repository/serve_stateless_test.go
@@ -86,6 +86,27 @@ func TestUploadPackRequestHasDone(t *testing.T) {
 	}
 }
 
+func TestStatelessUploadPackRequestSizeLimit(t *testing.T) {
+	ctx := t.Context()
+	root := t.TempDir()
+
+	bare, _ := buildParityUpstream(t, root)
+	repo, err := Open(bare)
+	if err != nil {
+		t.Fatalf("open repository: %v", err)
+	}
+
+	oversized := bytes.NewReader(make([]byte, maxUploadPackRequestSize+1))
+	var out bytes.Buffer
+	err = repo.Stateless(ctx, &out, oversized, GitUploadPack, "", ReceivePackHooks{})
+	if err == nil || !strings.Contains(err.Error(), "maximum size") {
+		t.Fatalf("oversized request should be rejected, got err=%v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("oversized request should produce no output, got %d bytes", out.Len())
+	}
+}
+
 func TestStatelessUploadPackNegotiationRound(t *testing.T) {
 	ctx := t.Context()
 	root := t.TempDir()

--- a/pkg/repository/serve_stateless_test.go
+++ b/pkg/repository/serve_stateless_test.go
@@ -1,0 +1,257 @@
+package repository
+
+// Tests for the v0/v1 stateless-RPC upload-pack round handling in serve.go:
+// each negotiation round arrives as an independent request and must be
+// answered with ACK/NAK without waiting for "done" in the same body.
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+)
+
+// unpackGitPack feeds a raw packfile to `git unpack-objects` in repoPath.
+func unpackGitPack(t *testing.T, repoPath string, pack []byte) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", "unpack-objects", "-q")
+	cmd.Dir = repoPath
+	cmd.Stdin = bytes.NewReader(pack)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git unpack-objects: %v\n%s", err, out)
+	}
+}
+
+// pktLines encodes pkt-lines; an empty string encodes a flush-pkt.
+func pktLines(t *testing.T, lines ...string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	for _, line := range lines {
+		if line == "" {
+			if err := pktline.WriteFlush(&buf); err != nil {
+				t.Fatalf("write flush: %v", err)
+			}
+			continue
+		}
+		if _, err := pktline.WriteString(&buf, line); err != nil {
+			t.Fatalf("write pkt-line: %v", err)
+		}
+	}
+	return buf.Bytes()
+}
+
+// readPktLines decodes all pkt-lines of a response; flush-pkts decode as "".
+func readPktLines(t *testing.T, data []byte) []string {
+	t.Helper()
+	rd := bytes.NewReader(data)
+	var lines []string
+	for rd.Len() > 0 {
+		l, line, err := pktline.ReadLine(rd)
+		if err != nil {
+			t.Fatalf("read pkt-line from %q: %v", data, err)
+		}
+		if l == pktline.Flush {
+			lines = append(lines, "")
+			continue
+		}
+		lines = append(lines, strings.TrimSuffix(string(line), "\n"))
+	}
+	return lines
+}
+
+func TestUploadPackRequestHasDone(t *testing.T) {
+	want := "want 0123456789012345678901234567890123456789 multi_ack_detailed\n"
+	cases := []struct {
+		name string
+		body []byte
+		want bool
+	}{
+		{"FlushOnlyProbe", pktLines(t, ""), false},
+		{"WantsAndHavesWithoutDone", pktLines(t, want, "", "have 89012345678901234567890123456789abcdef01\n", ""), false},
+		{"WantsWithDone", pktLines(t, want, "", "done\n"), true},
+		{"HavesThenDone", pktLines(t, want, "", "have 89012345678901234567890123456789abcdef01\n", "done\n"), true},
+		{"DoneWithoutNewline", pktLines(t, want, "", "done"), true},
+		{"Truncated", []byte("0012want incomplete"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := uploadPackRequestHasDone(tc.body); got != tc.want {
+				t.Fatalf("uploadPackRequestHasDone(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStatelessUploadPackNegotiationRound(t *testing.T) {
+	ctx := t.Context()
+	root := t.TempDir()
+
+	bare, work := buildParityUpstream(t, root)
+	repo, err := Open(bare)
+	if err != nil {
+		t.Fatalf("open repository: %v", err)
+	}
+	refs := gitLocalRefs(t, bare)
+	mainHash := refs["refs/heads/main"]
+
+	// A hash the server cannot have: a commit created only in the work repo
+	// after the last push.
+	commitFile(t, work, "file.txt", "local only\n", "local only")
+	localOnly := strings.TrimSpace(gitOut(t, work, "rev-parse", "HEAD"))
+
+	serve := func(t *testing.T, body []byte) []string {
+		t.Helper()
+		var out bytes.Buffer
+		if err := repo.Stateless(ctx, &out, bytes.NewReader(body), GitUploadPack, "", ReceivePackHooks{}); err != nil {
+			t.Fatalf("Stateless: %v", err)
+		}
+		return readPktLines(t, out.Bytes())
+	}
+
+	wantLine := fmt.Sprintf("want %s multi_ack_detailed\n", mainHash)
+
+	t.Run("FlushOnlyProbe", func(t *testing.T) {
+		if got := serve(t, pktLines(t, "")); len(got) != 0 {
+			t.Fatalf("probe request should produce no output, got %q", got)
+		}
+	})
+
+	t.Run("RoundWithUnknownHaves", func(t *testing.T) {
+		body := pktLines(t, wantLine, "",
+			fmt.Sprintf("have %s\n", localOnly), "")
+		got := serve(t, body)
+		want := []string{"NAK"}
+		if strings.Join(got, "|") != strings.Join(want, "|") {
+			t.Fatalf("round response = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("RoundWithCommonHaves", func(t *testing.T) {
+		body := pktLines(t, wantLine, "",
+			fmt.Sprintf("have %s\n", localOnly),
+			fmt.Sprintf("have %s\n", mainHash), "")
+		got := serve(t, body)
+		want := []string{
+			fmt.Sprintf("ACK %s common", mainHash),
+			"NAK",
+		}
+		if strings.Join(got, "|") != strings.Join(want, "|") {
+			t.Fatalf("round response = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("MultiAckRound", func(t *testing.T) {
+		body := pktLines(t,
+			fmt.Sprintf("want %s multi_ack\n", mainHash), "",
+			fmt.Sprintf("have %s\n", mainHash), "")
+		got := serve(t, body)
+		want := []string{
+			fmt.Sprintf("ACK %s continue", mainHash),
+			"NAK",
+		}
+		if strings.Join(got, "|") != strings.Join(want, "|") {
+			t.Fatalf("round response = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("SingleAckRound", func(t *testing.T) {
+		body := pktLines(t,
+			fmt.Sprintf("want %s\n", mainHash), "",
+			fmt.Sprintf("have %s\n", mainHash), "")
+		got := serve(t, body)
+		want := []string{fmt.Sprintf("ACK %s", mainHash)}
+		if strings.Join(got, "|") != strings.Join(want, "|") {
+			t.Fatalf("round response = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("FinalRoundWithDoneSendsPack", func(t *testing.T) {
+		var out bytes.Buffer
+		body := pktLines(t, wantLine, "", "done\n")
+		if err := repo.Stateless(ctx, &out, bytes.NewReader(body), GitUploadPack, "", ReceivePackHooks{}); err != nil {
+			t.Fatalf("Stateless final round: %v", err)
+		}
+		resp := out.Bytes()
+		lines := readPktLines(t, resp[:8]) // first pkt-line only: "0008NAK\n"
+		if len(lines) == 0 || lines[0] != "NAK" {
+			t.Fatalf("final round should start with NAK, got %q", resp[:min(16, len(resp))])
+		}
+		if !bytes.Contains(resp, []byte("PACK")) {
+			t.Fatalf("final round response should contain a packfile")
+		}
+	})
+}
+
+// TestStatelessUploadPackFullNegotiation drives a complete multi-round
+// stateless negotiation the way a real smart-HTTP client does: rounds are
+// separate requests replaying the accumulated state, ending with done.
+func TestStatelessUploadPackFullNegotiation(t *testing.T) {
+	ctx := t.Context()
+	root := t.TempDir()
+
+	bare, work := buildParityUpstream(t, root)
+	repo, err := Open(bare)
+	if err != nil {
+		t.Fatalf("open repository: %v", err)
+	}
+
+	// The client has the old main plus local-only history the server lacks.
+	oldMain := gitLocalRefs(t, bare)["refs/heads/main"]
+	commitFile(t, work, "file.txt", "new upstream\n", "new upstream")
+	runGit(t, work, "push", "origin", "main")
+	newMain := gitLocalRefs(t, bare)["refs/heads/main"]
+
+	wantLine := fmt.Sprintf("want %s multi_ack_detailed\n", newMain)
+	unknown := strings.Repeat("ab", 20)
+
+	// Round 1: only haves the server does not know -> NAK, keep negotiating.
+	round1 := pktLines(t, wantLine, "", fmt.Sprintf("have %s\n", unknown), "")
+	var out1 bytes.Buffer
+	if err := repo.Stateless(ctx, &out1, bytes.NewReader(round1), GitUploadPack, "", ReceivePackHooks{}); err != nil {
+		t.Fatalf("round 1: %v", err)
+	}
+	if got := readPktLines(t, out1.Bytes()); len(got) != 1 || got[0] != "NAK" {
+		t.Fatalf("round 1 response = %q, want [NAK]", got)
+	}
+
+	// Round 2: replayed state plus a common have -> ACK common, NAK.
+	round2 := pktLines(t, wantLine, "",
+		fmt.Sprintf("have %s\n", unknown),
+		fmt.Sprintf("have %s\n", oldMain), "")
+	var out2 bytes.Buffer
+	if err := repo.Stateless(ctx, &out2, bytes.NewReader(round2), GitUploadPack, "", ReceivePackHooks{}); err != nil {
+		t.Fatalf("round 2: %v", err)
+	}
+	got2 := readPktLines(t, out2.Bytes())
+	want2 := []string{fmt.Sprintf("ACK %s common", oldMain), "NAK"}
+	if strings.Join(got2, "|") != strings.Join(want2, "|") {
+		t.Fatalf("round 2 response = %q, want %q", got2, want2)
+	}
+
+	// Final round: full state plus done -> ACK/pack.
+	final := pktLines(t, wantLine, "",
+		fmt.Sprintf("have %s\n", oldMain),
+		"done\n")
+	var out3 bytes.Buffer
+	if err := repo.Stateless(ctx, &out3, bytes.NewReader(final), GitUploadPack, "", ReceivePackHooks{}); err != nil {
+		t.Fatalf("final round: %v", err)
+	}
+	if !bytes.Contains(out3.Bytes(), []byte("PACK")) {
+		t.Fatalf("final response should contain a packfile")
+	}
+
+	// The pack must be usable by the git binary: index it into a scratch
+	// repository and verify the wanted commit becomes readable.
+	resp := out3.Bytes()
+	packStart := bytes.Index(resp, []byte("PACK"))
+	scratch := filepath.Join(root, "scratch.git")
+	runGit(t, "", "init", "--bare", "--initial-branch=main", scratch)
+	unpackGitPack(t, scratch, resp[packStart:])
+	if typ := strings.TrimSpace(gitOut(t, scratch, "cat-file", "-t", newMain)); typ != "commit" {
+		t.Fatalf("wanted commit not usable from negotiated pack, cat-file -t = %q", typ)
+	}
+}


### PR DESCRIPTION
Follow-up to #187: adds parity tests that compare the go-git implementations against the git commands they replaced, and fixes the regressions they caught.

The client-side suite (`pkg/repository/mirror_parity_test.go`) runs `GetRemoteRefs`/`GetRemoteDefaultBranch`/`PullMirrorRefs`/`PushMirrorRefs` side by side with `git ls-remote`/`git fetch`/`git push` over both the file transport and a real `git http-backend` CGI, cross-checking go-git-written repos with `git fsck`/`for-each-ref`/`cat-file`. The server-side suite (`pkg/backend/http/handler_parity_test.go`) drives a real git client under protocol v0 and v2 against the production handler and a `git http-backend` twin serving identical repos.

Regressions fixed:

- `PushMirrorRefs` with prune deleted every ref on the destination on the second push (the production wildcard mirror-push path). go-git's `PushOptions.Prune` reverses refspecs with the force prefix left on the destination side (`+refs/heads/*:refs/heads/*` → `refs/heads/*:+refs/heads/*`), so the local-existence lookup never matches; it also removes local refs missing on the remote. Prune deletions are now computed in `pushPruneRefSpecs` instead.
- `GetRemoteRefs` errored on empty repositories; `git ls-remote --refs` prints nothing and exits 0. Now returns an empty map, which mirror init/prune against empty destinations depends on.
- The upload-pack handshake used wire protocol v0 (`transport.Request.Protocol` zero value), which can't advertise an unborn HEAD symref. Now requests v2 like the git binary, so `GetRemoteDefaultBranch` resolves empty upstreams the same way `git clone` does.
- The HTTP handler fed gzip request bodies straight into the pkt-line parser. git compresses smart-HTTP POST bodies over 1KiB (remote-curl.c `post_rpc`) and `git http-backend` inflates them (`inflate_request`); the handler now does the same, so large fetch negotiations no longer 500.
- v0 stateless-RPC fetch negotiation failed on intermediate rounds: go-git's `transport.UploadPack` keeps reading rounds from one request body until "done", but in stateless RPC each round is a separate request. `Stateless` now answers rounds without "done" with a single ACK/NAK round (`serveStatelessUploadPackV0`), matching `git upload-pack --stateless-rpc`; final rounds still go through go-git. Clones worked before because the first round already carries "done" — only incremental v0 fetches were broken.

The gzip and v0 negotiation paths also have direct unit tests (`handler_gzip_test.go`, `serve_stateless_test.go`), including a full three-round stateless negotiation whose resulting pack is fed to `git unpack-objects`.

Known gaps, left as-is:

- go-git's server side doesn't implement ls-refs `unborn`, so cloning an empty repo served by us lands on the client's `init.defaultBranch` rather than the repo's actual unborn branch (worked in the subprocess era). Needs an upstream go-git change; the parity test encodes the current behavior.
- A v0 stateless shallow fetch (wants + `deepen`, no haves/done) still fails: the round handler hits EOF in `UploadHaves.Decode`. Not a regression — the pre-PR go-git path EOF'd on it too, and v2 (the default for modern clients) handles shallow.
